### PR TITLE
globalNavigationにbreakpointを追加

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -5,7 +5,12 @@ import styled from 'styled-components';
 const OldFashionedLinkButton = styled((props) => (
   <Link {...props} />
 ))`
-  display: block;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  box-sizing: border-box;
   padding: 12px;
   background-color: #bfbfbf;
   border-style: solid;
@@ -32,7 +37,8 @@ const OldFashionedLinkButton = styled((props) => (
 `;
 
 const ButtonContainer = styled.div`
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   border: solid #000000 2px;
   text-align: center;
 `;
@@ -42,17 +48,17 @@ interface ButtonPropertyType {
   text: String;
 }
 
-function Button(props: ButtonPropertyType) {
+const Button = (props: ButtonPropertyType) => {
   return (
     <ButtonContainer>
       <OldFashionedLinkButton
         to={props.path}
         activeClassName="current"
       >
-        {props.text}
+        <span>{props.text}</span>
       </OldFashionedLinkButton>
     </ButtonContainer>
   );
-}
+};
 
 export default Button;

--- a/src/components/globalNavigation.tsx
+++ b/src/components/globalNavigation.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useBreakpoint } from 'gatsby-plugin-breakpoints';
 import styled from 'styled-components';
 import Button from './button';
 
@@ -25,26 +26,37 @@ const contents = [
   },
 ];
 
+type Props = {
+  isMobile: boolean;
+};
+
 const MenuList = styled.ul`
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   list-style: none;
   margin: 0;
   padding: 10px;
   background-color: #bfbfbf;
 `;
 
-const MenuItem = styled.li`
-  flex: 0 0 calc(${100 / contents.length}% - 20px);
+const MenuItem = styled.li.attrs((props: Props) => ({
+  isMobile: props.isMobile,
+}))`
+  flex: ${(props) =>
+    props.isMobile
+      ? '1 0 33%'
+      : `0 0 calc(${100 / contents.length}% - 20px)`};
   display: flex;
   div {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
   }
 `;
 
 const GlobalNavigation = () => {
+  const breakpoints = useBreakpoint();
   const menuItems = contents.map((item, index) => (
-    <MenuItem key={index}>
+    <MenuItem key={index} isMobile={breakpoints.sm}>
       <Button text={item.text} path={item.path} />
     </MenuItem>
   ));

--- a/types/graphql-types.d.ts
+++ b/types/graphql-types.d.ts
@@ -2265,6 +2265,8 @@ export type QueryAllDirectoryArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<IntQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -2438,6 +2440,8 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Int']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -2640,6 +2644,8 @@ export type SiteFieldsEnum =
   | 'siteMetadata___title'
   | 'siteMetadata___description'
   | 'siteMetadata___keywords'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -2732,6 +2738,8 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<IntQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;


### PR DESCRIPTION
close #126 

- メニューボタンのスタイルを見直しました。
- globalNavigationにbreakpointを追加しました。 `sm` でカラム落ちするようにしました。

![スクリーンショット 2020-11-29 13 52 32](https://user-images.githubusercontent.com/14883063/100533883-b9bce600-324c-11eb-9a37-5958838ea914.png)

![スクリーンショット 2020-11-29 13 53 07](https://user-images.githubusercontent.com/14883063/100533886-c0e3f400-324c-11eb-959d-3c80e62fd394.png)
