### PR TITLE
Feature/issue 107 list of contents

### DIFF
--- a/src/components/globalNavigation.tsx
+++ b/src/components/globalNavigation.tsx
@@ -9,7 +9,7 @@ const contents = [
   },
   {
     text: '供養塔',
-    path: '/case-study',
+    path: '/list-of-contents',
   },
   {
     text: '宝蔵',

--- a/src/components/listOfContents.tsx
+++ b/src/components/listOfContents.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+const ContentsList = styled.ul`
+  list-style: none;
+  margin: 10px 0;
+  padding: 10px;
+`;
+
+const ContentsListItem = styled.li`
+  display: block;
+`;
+
+interface INode {
+  id: string;
+  frontmatter: {
+    title: string;
+    slug: string;
+    date: string;
+  };
+}
+
+interface IProp {
+  contents: INode[];
+}
+
+export default function ListOfContents(props: IProp) {
+  console.log(props);
+  const listItems = props.contents.map((item, index) => (
+    <ContentsListItem key={index}>
+      <a href={item.frontmatter!.slug}>
+        {item.frontmatter!.title} - {item.frontmatter!.date}
+      </a>
+    </ContentsListItem>
+  ));
+  return <ContentsList>{listItems}</ContentsList>;
+}

--- a/src/pages/list-of-contents.tsx
+++ b/src/pages/list-of-contents.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { graphql } from 'gatsby';
+import ListOfContents from '../components/listOfContents.tsx';
+import Layout from '../components/layout';
+import { ListOfContentsQueryQuery } from '../../types/graphql-types';
+
+interface IProps {
+  data: ListOfContentsQueryQuery;
+}
+
+export default function ListOfContentsPage({
+  data,
+}: IProps) {
+  return (
+    <Layout>
+      <ListOfContents
+        contents={data.allMarkdownRemark.edges.map(
+          (item) => item.node,
+        )}
+      />
+    </Layout>
+  );
+}
+export const pageQuery = graphql`
+  query ListOfContentsQuery {
+    allMarkdownRemark(filter: {fileAbsolutePath: {regex: "s/.+\\/markdown\\/articles\\/[^\\/]+\\.md/"}}, sort: {fields: frontmatter___date, order: DESC}) {
+      edges {
+        node {
+          id
+          frontmatter {
+            title
+            slug
+            date
+          }
+        }
+      }
+    }
+  }
+`;

--- a/types/graphql-types.d.ts
+++ b/types/graphql-types.d.ts
@@ -2265,6 +2265,8 @@ export type QueryAllDirectoryArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<IntQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -2438,6 +2440,8 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Int']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -2640,6 +2644,8 @@ export type SiteFieldsEnum =
   | 'siteMetadata___title'
   | 'siteMetadata___description'
   | 'siteMetadata___keywords'
+  | 'port'
+  | 'host'
   | 'polyfill'
   | 'pathPrefix'
   | 'id'
@@ -2732,6 +2738,8 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<IntQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -3620,6 +3628,14 @@ export type IndexQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type IndexQueryQuery = { site?: Maybe<{ siteMetadata?: Maybe<Pick<SiteSiteMetadata, 'title' | 'description'>> }> };
+
+export type ListOfContentsQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ListOfContentsQueryQuery = { allMarkdownRemark: { edges: Array<{ node: (
+        Pick<MarkdownRemark, 'id'>
+        & { frontmatter?: Maybe<Pick<MarkdownRemarkFrontmatter, 'title' | 'slug' | 'date'>> }
+      ) }> } };
 
 export type BlogTemplateQueryVariables = Exact<{
   slug: Scalars['String'];


### PR DESCRIPTION
closes #107 

List all the markdowns in `src/contents/markdown/article/` (direct children only).
Implemented as a plane link.

![image](https://user-images.githubusercontent.com/3675691/100540264-9cedd600-327f-11eb-82d6-b84ba75a800d.png)
