### PR TITLE
fix: 除夜の鐘モード

### DIFF
--- a/src/components/bigBell.tsx
+++ b/src/components/bigBell.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Rnd } from 'react-rnd';
 import Omikuji from './omikuji';
 
-const BigBellContainer = styled.div`
+const BigBellContainer = styled.div<{ display: boolean }>`
   position: absolute;
   pointer-events: none;
   display: ${(props) => (props.display ? 'flex' : 'none')};
@@ -35,7 +35,10 @@ const StickContainer = styled.div`
   height: 50%;
 `;
 
-const Counter = styled.p`
+const Counter = styled.p<{
+  margin: number;
+  fontSize: number;
+}>`
   margin-bottom: ${(props) => props.margin}px;
   font-size: ${(props) => props.fontSize}px;
 `;
@@ -112,7 +115,7 @@ const BigBell = () => {
 
   return (
     <>
-      <BigBellContainer display="true">
+      <BigBellContainer display>
         <StickContainer>
           <Rnd
             style={style}
@@ -187,7 +190,7 @@ const BigBell = () => {
           </audio>
         </StickContainer>
       </BigBellContainer>
-      <BigBellContainer display="true">
+      <BigBellContainer display>
         <div>
           <BigBellImg
             fluid={data.bigBell.childImageSharp.fluid}
@@ -195,7 +198,7 @@ const BigBell = () => {
           />
         </div>
       </BigBellContainer>
-      <BigBellContainer display="true">
+      <BigBellContainer display>
         <Counter
           margin={windowWidth / 5}
           fontSize={windowWidth / 50}

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -71,6 +71,31 @@ const TempleImg = styled((props) => <Img {...props} />)`
   align-items: flex-end;
 `;
 
+const currentTime = moment();
+
+const times = SunCalc.getTimes(
+  new Date(),
+  35.6275256,
+  139.7714723,
+);
+
+const isDayTime = currentTime.isBetween(
+  times.sunriseEnd,
+  times.night,
+);
+
+const isLastDay = currentTime.isSame(
+  moment().endOf('year'),
+  'day',
+);
+
+const isSanganichi = currentTime.isBetween(
+  moment().startOf('year').dayOfYear(0),
+  moment().startOf('year').dayOfYear(3),
+);
+
+const isActiveJyoyaMode = isLastDay || isSanganichi;
+
 const Hero = () => {
   const data = useStaticQuery(
     graphql`
@@ -132,21 +157,6 @@ const Hero = () => {
     setIsUnderConstruction,
   ] = useState(false);
 
-  const currentTime = moment();
-  const times = SunCalc.getTimes(
-    new Date(),
-    35.6275256,
-    139.7714723,
-  );
-  const isDayTime = currentTime.isBetween(
-    times.sunriseEnd,
-    times.night,
-  );
-  const isLastDay = currentTime.isSame(
-    moment().endOf('year'),
-    'day',
-  );
-
   return (
     <HeroContainer>
       <ButtonContainer>
@@ -166,7 +176,7 @@ const Hero = () => {
           />
         </div>
       </LogoContainer>
-      {isLastDay ? (
+      {isActiveJyoyaMode ? (
         <BigBell />
       ) : (
         <>


### PR DESCRIPTION
close #178 
- bigBell の型エラーの修正
- 除夜の鐘モードの条件を大晦日だけでなく三が日も含めるように更新
- 日付の計算処理をコンポーネント外で行うように修正

崩れを再現している `Chrome（シークレットウインドウ）` で問題なく表示されていることを確認
https://yokinist.github.io/bad-opendata-temple 
※ インデックスされると困るので robots.txt でクロール拒否しています

---

最新の develop ブランチを見たところローカルと github pages でも共に寺が崩れている現象が再現できなかったのでちょっと謎ですが、恐らく master に反映しなおしたら直るかと思います