### PR TITLE
hotfix: (再び)寺の崩壊

### DIFF
--- a/src/components/bigBell.tsx
+++ b/src/components/bigBell.tsx
@@ -8,7 +8,8 @@ import Omikuji from './omikuji';
 const BigBellContainer = styled.div<{ display: boolean }>`
   position: absolute;
   pointer-events: none;
-  display: ${(props) => (props.display ? 'flex' : 'none')};
+  display: ${(props) =>
+    props.display ? 'flex' : 'none !important'};
   justify-content: center;
   width: 100%;
   align-items: flex-end;

--- a/src/components/bigBell.tsx
+++ b/src/components/bigBell.tsx
@@ -8,8 +8,7 @@ import Omikuji from './omikuji';
 const BigBellContainer = styled.div<{ display: boolean }>`
   position: absolute;
   pointer-events: none;
-  display: ${(props) =>
-    props.display ? 'flex' : 'none !important'};
+  display: ${(props) => (props.display ? 'flex' : 'none')};
   justify-content: center;
   width: 100%;
   align-items: flex-end;

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -51,7 +51,9 @@ const ButtonContainer = styled.div`
   top: 0;
   right: 0;
 `;
-const TempleContainer = styled.div`
+const TempleContainer = styled.div<{
+  isActiveJyoyaMode: boolean;
+}>`
   position: absolute;
   pointer-events: none;
   display: flex;
@@ -62,7 +64,8 @@ const TempleContainer = styled.div`
   z-index: 2;
   > div {
     text-align: center;
-    width: 50%;
+    width: ${({ isActiveJyoyaMode }) =>
+      isActiveJyoyaMode ? '100%' : '50%'};
     display: flex;
   }
 `;
@@ -84,18 +87,17 @@ const isDayTime = currentTime.isBetween(
   times.night,
 );
 
-// const isLastDay = currentTime.isSame(
-//   moment().endOf('year'),
-//   'day',
-// );
+const isLastDay = currentTime.isSame(
+  moment().endOf('year'),
+  'day',
+);
 
-// const isSanganichi = currentTime.isBetween(
-//   moment().startOf('year').dayOfYear(0),
-//   moment().startOf('year').dayOfYear(4),
-// );
+const isSanganichi = currentTime.isBetween(
+  moment().startOf('year').dayOfYear(0),
+  moment().startOf('year').dayOfYear(4),
+);
 
-// TODO: 可変でもレイアウト崩れが起きないようにする
-const isActiveJyoyaMode = false; // isLastDay || isSanganichi;
+const isActiveJyoyaMode = isLastDay || isSanganichi;
 
 const Hero = () => {
   const data = useStaticQuery(
@@ -177,12 +179,14 @@ const Hero = () => {
           />
         </div>
       </LogoContainer>
-      {isActiveJyoyaMode ? (
-        <BigBell />
-      ) : (
-        <>
-          <Mochimaki />
-          <TempleContainer>
+      <>
+        {!isActiveJyoyaMode && <Mochimaki />}
+        <TempleContainer
+          isActiveJyoyaMode={isActiveJyoyaMode}
+        >
+          {isActiveJyoyaMode ? (
+            <BigBell />
+          ) : (
             <div>
               <TempleImg
                 fluid={
@@ -194,9 +198,9 @@ const Hero = () => {
                 alt="本堂"
               />
             </div>
-          </TempleContainer>
-        </>
-      )}
+          )}
+        </TempleContainer>
+      </>
       <ScaffoldContainer>
         <div>
           {isUnderConstruction && (

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -84,17 +84,18 @@ const isDayTime = currentTime.isBetween(
   times.night,
 );
 
-const isLastDay = currentTime.isSame(
-  moment().endOf('year'),
-  'day',
-);
+// const isLastDay = currentTime.isSame(
+//   moment().endOf('year'),
+//   'day',
+// );
 
-const isSanganichi = currentTime.isBetween(
-  moment().startOf('year').dayOfYear(0),
-  moment().startOf('year').dayOfYear(4),
-);
+// const isSanganichi = currentTime.isBetween(
+//   moment().startOf('year').dayOfYear(0),
+//   moment().startOf('year').dayOfYear(4),
+// );
 
-const isActiveJyoyaMode = isLastDay || isSanganichi;
+// TODO: 可変でもレイアウト崩れが起きないようにする
+const isActiveJyoyaMode = false; // isLastDay || isSanganichi;
 
 const Hero = () => {
   const data = useStaticQuery(

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -51,9 +51,8 @@ const ButtonContainer = styled.div`
   top: 0;
   right: 0;
 `;
-const TempleContainer = styled.div<{
-  isActiveJyoyaMode: boolean;
-}>`
+
+const TempleContainer = styled.div`
   position: absolute;
   pointer-events: none;
   display: flex;
@@ -62,13 +61,14 @@ const TempleContainer = styled.div<{
   align-items: flex-end;
   height: 100%;
   z-index: 2;
-  > div {
-    text-align: center;
-    width: ${({ isActiveJyoyaMode }) =>
-      isActiveJyoyaMode ? '100%' : '50%'};
-    display: flex;
-  }
 `;
+
+const TempleContent = styled.div`
+  text-align: center;
+  width: 50%;
+  display: flex;
+`;
+
 const TempleImg = styled((props) => <Img {...props} />)`
   flex: 1 1 auto;
   align-items: flex-end;
@@ -187,7 +187,7 @@ const Hero = () => {
           {isActiveJyoyaMode ? (
             <BigBell />
           ) : (
-            <div>
+            <TempleContent>
               <TempleImg
                 fluid={
                   isDayTime
@@ -197,7 +197,7 @@ const Hero = () => {
                 }
                 alt="本堂"
               />
-            </div>
+            </TempleContent>
           )}
         </TempleContainer>
       </>


### PR DESCRIPTION
close #181 

描画前一瞬 isActiveJyoyaMode が true になってから false になるので、恐らく切り替わる際に高さの確保がうまくいっていないのが原因なようです。 ~読み込みの遅延やレイアウトの組み方を修正するなどといったアプローチが本来は良さそうですが、今も崩壊してしまっているので秩序を取り戻すため値を直書きで固定にして対処しました~ -> レイアウトの組み方で解決しました