### PR TITLE
actionsのnode-versionを16.xにする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '16.x'
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path


### PR DESCRIPTION
github actionsがnode-versionでコケるので、16系にあげてみます。